### PR TITLE
Remove console.{log,error} from the codebase

### DIFF
--- a/packages/account-actions/create-database.js
+++ b/packages/account-actions/create-database.js
@@ -26,6 +26,7 @@ function createDatabase(cloudant, dbName) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/create-database.js
+++ b/packages/account-actions/create-database.js
@@ -24,10 +24,8 @@ function createDatabase(cloudant, dbName) {
     return new Promise(function (resolve, reject) {
         cloudant.db.create(dbName, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/delete-database.js
+++ b/packages/account-actions/delete-database.js
@@ -23,10 +23,8 @@ function destroyDatabase(cloudant, dbName) {
     return new Promise(function (resolve, reject) {
         cloudant.db.destroy(dbName, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/delete-database.js
+++ b/packages/account-actions/delete-database.js
@@ -25,6 +25,7 @@ function destroyDatabase(cloudant, dbName) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/list-all-databases.js
+++ b/packages/account-actions/list-all-databases.js
@@ -18,13 +18,11 @@ function listAllDatabases(cloudant) {
     return new Promise(function (resolve, reject) {
         cloudant.db.list(function (error, response) {
             if (!error) {
-                console.log('success', response);
                 //Response is an array and only JSON objects can be passed
                 var responseObj = {};
                 responseObj.all_databases = response;
                 resolve(responseObj);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/list-all-databases.js
+++ b/packages/account-actions/list-all-databases.js
@@ -23,6 +23,7 @@ function listAllDatabases(cloudant) {
                 responseObj.all_databases = response;
                 resolve(responseObj);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/read-database.js
+++ b/packages/account-actions/read-database.js
@@ -25,6 +25,7 @@ function readDatabase(cloudant, dbName) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/account-actions/read-database.js
+++ b/packages/account-actions/read-database.js
@@ -23,10 +23,8 @@ function readDatabase(cloudant, dbName) {
     return new Promise(function (resolve, reject) {
         cloudant.db.get(dbName, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/create-document.js
+++ b/packages/database-actions/create-document.js
@@ -57,6 +57,7 @@ function insert(cloudantDb, doc, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/create-document.js
+++ b/packages/database-actions/create-document.js
@@ -55,10 +55,8 @@ function insert(cloudantDb, doc, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.insert(doc, params, function (error, response) {
             if (!error) {
-                console.log("success", response);
                 resolve(response);
             } else {
-                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/create-query-index.js
+++ b/packages/database-actions/create-query-index.js
@@ -29,10 +29,8 @@ function createIndex(cloudantDb, index) {
     return new Promise(function (resolve, reject) {
         cloudantDb.index(index, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(response);
             }
         });

--- a/packages/database-actions/create-query-index.js
+++ b/packages/database-actions/create-query-index.js
@@ -31,6 +31,7 @@ function createIndex(cloudantDb, index) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(response);
             }
         });

--- a/packages/database-actions/create-update-attachment.js
+++ b/packages/database-actions/create-update-attachment.js
@@ -61,6 +61,7 @@ function insert(cloudantDb, docId, attName, att, contentType, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/create-update-attachment.js
+++ b/packages/database-actions/create-update-attachment.js
@@ -59,10 +59,8 @@ function insert(cloudantDb, docId, attName, att, contentType, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.attachment.insert(docId, attName, att, contentType, params, function (error, response) {
             if (!error) {
-                console.log("success", response);
                 resolve(response);
             } else {
-                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-attachment.js
+++ b/packages/database-actions/delete-attachment.js
@@ -56,6 +56,7 @@ function deleteAttachment(cloudantDb, docId, attName, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-attachment.js
+++ b/packages/database-actions/delete-attachment.js
@@ -54,10 +54,8 @@ function deleteAttachment(cloudantDb, docId, attName, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.attachment.destroy(docId, attName, params, function (error, response) {
             if (!error) {
-                console.log("success", response);
                 resolve(response);
             } else {
-                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-document.js
+++ b/packages/database-actions/delete-document.js
@@ -37,10 +37,8 @@ function destroy(cloudantDb, docId, docRev) {
     return new Promise(function (resolve, reject) {
         cloudantDb.destroy(docId, docRev, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-document.js
+++ b/packages/database-actions/delete-document.js
@@ -39,6 +39,7 @@ function destroy(cloudantDb, docId, docRev) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-query-index.js
+++ b/packages/database-actions/delete-query-index.js
@@ -47,6 +47,7 @@ function deleteIndexFromDesignDoc(cloudant, docId, indexName, indexType, dbName)
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-query-index.js
+++ b/packages/database-actions/delete-query-index.js
@@ -45,10 +45,8 @@ function deleteIndexFromDesignDoc(cloudant, docId, indexName, indexType, dbName)
             path: path
         }, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-view.js
+++ b/packages/database-actions/delete-view.js
@@ -50,7 +50,6 @@ function deleteViewFromDesignDoc(cloudantDb, docId, viewName, params) {
 
     return getDocument(cloudantDb, docId)
     .then(function (document) {
-        console.log("Got document: " + document);
         delete document.views[viewName];
 
         //Update the design document after removing the view
@@ -62,10 +61,8 @@ function getDocument(cloudantDb, docId) {
     return new Promise(function (resolve, reject) {
         cloudantDb.get(docId, function (error, response) {
             if (!error) {
-                console.log("Got response: " + response);
                 resolve(response);
             } else {
-                console.log("Got error: " + error);
                 reject(error);
             }
         });
@@ -76,10 +73,8 @@ function insert(cloudantDb, doc, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.insert(doc, params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/delete-view.js
+++ b/packages/database-actions/delete-view.js
@@ -63,6 +63,7 @@ function getDocument(cloudantDb, docId) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log("Got error: " + error);
                 reject(error);
             }
         });
@@ -75,6 +76,7 @@ function insert(cloudantDb, doc, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-find.js
+++ b/packages/database-actions/exec-query-find.js
@@ -42,10 +42,8 @@ function queryIndex(cloudantDb, query) {
     return new Promise(function (resolve, reject) {
         cloudantDb.find(query, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-find.js
+++ b/packages/database-actions/exec-query-find.js
@@ -44,6 +44,7 @@ function queryIndex(cloudantDb, query) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-search.js
+++ b/packages/database-actions/exec-query-search.js
@@ -52,6 +52,7 @@ function querySearch(cloudantDb, designDocId, designViewName, search) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-search.js
+++ b/packages/database-actions/exec-query-search.js
@@ -50,10 +50,8 @@ function querySearch(cloudantDb, designDocId, designViewName, search) {
     return new Promise(function (resolve, reject) {
         cloudantDb.search(designDocId, designViewName, search, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-view.js
+++ b/packages/database-actions/exec-query-view.js
@@ -49,6 +49,7 @@ function queryView(cloudantDb, designDocId, designDocViewName, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/exec-query-view.js
+++ b/packages/database-actions/exec-query-view.js
@@ -47,10 +47,8 @@ function queryView(cloudantDb, designDocId, designDocViewName, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.view(designDocId, designDocViewName, params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-design-documents.js
+++ b/packages/database-actions/list-design-documents.js
@@ -25,7 +25,6 @@ function main(message) {
 
     //If includeDoc exists and is true, add field to additional params object
     includeDocs = includeDocs.toString().trim().toLowerCase();
-    console.log('includeDocs: ' + includeDocs);
     if (includeDocs === 'true') {
         params.include_docs = 'true';
     }
@@ -40,10 +39,8 @@ function listDesignDocuments(cloudantDb, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.list(params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-design-documents.js
+++ b/packages/database-actions/list-design-documents.js
@@ -41,6 +41,7 @@ function listDesignDocuments(cloudantDb, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-documents.js
+++ b/packages/database-actions/list-documents.js
@@ -39,10 +39,8 @@ function listAllDocuments(cloudantDb, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.list(params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-documents.js
+++ b/packages/database-actions/list-documents.js
@@ -41,6 +41,7 @@ function listAllDocuments(cloudantDb, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-query-indexes.js
+++ b/packages/database-actions/list-query-indexes.js
@@ -25,10 +25,8 @@ function index(cloudantDb) {
     return new Promise(function (resolve, reject) {
         cloudantDb.index(function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/list-query-indexes.js
+++ b/packages/database-actions/list-query-indexes.js
@@ -27,6 +27,7 @@ function index(cloudantDb) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/manage-bulk-documents.js
+++ b/packages/database-actions/manage-bulk-documents.js
@@ -54,10 +54,8 @@ function bulk(cloudantDb, docs, params) {
             if (!error) {
                 var responseDocs = {};
                 responseDocs.docs = response;
-                console.log('success', response);
                 resolve(responseDocs);
             } else {
-                console.log('Error: ', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/manage-bulk-documents.js
+++ b/packages/database-actions/manage-bulk-documents.js
@@ -56,6 +56,7 @@ function bulk(cloudantDb, docs, params) {
                 responseDocs.docs = response;
                 resolve(responseDocs);
             } else {
+                console.log('Error: ', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-attachment.js
+++ b/packages/database-actions/read-attachment.js
@@ -54,6 +54,7 @@ function read(cloudantDb, docId, attName, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-attachment.js
+++ b/packages/database-actions/read-attachment.js
@@ -52,10 +52,8 @@ function read(cloudantDb, docId, attName, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.attachment.get(docId, attName, params, function (error, response) {
             if (!error) {
-                console.log("success", response);
                 resolve(response);
             } else {
-                console.log("error", error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-changes-feed.js
+++ b/packages/database-actions/read-changes-feed.js
@@ -35,10 +35,8 @@ function changes(cloudant, dbName, params) {
     return new Promise(function (resolve, reject) {
         cloudant.db.changes(dbName, params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-changes-feed.js
+++ b/packages/database-actions/read-changes-feed.js
@@ -37,6 +37,7 @@ function changes(cloudant, dbName, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-document.js
+++ b/packages/database-actions/read-document.js
@@ -42,6 +42,7 @@ function readDocument(cloudantDb, docId, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/read-document.js
+++ b/packages/database-actions/read-document.js
@@ -40,10 +40,8 @@ function readDocument(cloudantDb, docId, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.get(docId, params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.error('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/update-document.js
+++ b/packages/database-actions/update-document.js
@@ -57,6 +57,7 @@ function insert(cloudantDb, doc, params) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/update-document.js
+++ b/packages/database-actions/update-document.js
@@ -55,10 +55,8 @@ function insert(cloudantDb, doc, params) {
     return new Promise(function (resolve, reject) {
         cloudantDb.insert(doc, params, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/write-document.js
+++ b/packages/database-actions/write-document.js
@@ -72,6 +72,7 @@ function insertOrUpdate(cloudantDb, overwrite, doc) {
                                     reject(err);
                                 });
                         } else {
+                            console.error('error', error);
                             reject(error);
                         }
                     }
@@ -96,6 +97,7 @@ function insert(cloudantDb, doc) {
             if (!error) {
                 resolve(response);
             } else {
+                console.log('error', error);
                 reject(error);
             }
         });

--- a/packages/database-actions/write-document.js
+++ b/packages/database-actions/write-document.js
@@ -72,7 +72,6 @@ function insertOrUpdate(cloudantDb, overwrite, doc) {
                                     reject(err);
                                 });
                         } else {
-                            console.error('error', error);
                             reject(error);
                         }
                     }
@@ -95,10 +94,8 @@ function insert(cloudantDb, doc) {
     return new Promise(function (resolve, reject) {
         cloudantDb.insert(doc, function (error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });


### PR DESCRIPTION
A standard pattern in this package is to print the contents of the Cloudant response to stdout through console.log before returning it in to the runtime. This is redundant because OpenWhisk itself provides methods to record and view the data being passed between actions. It's also harmful for two reasons:

1. Unnecessary platform logging. The platform logs for our Cloudant instance are captured for compliance reasons. In our workload, we were literally paying twice as much for log file parsing as for
our OpenWhisk processing, as the body of every database document was ending up in the logs (and some were quite big)

2. Security. The document bodies ending up in the logs meant that log file 'read' permissions were being effectively escalated to ersatz database 'read' permissions. In particular, our compliance team could, but shouldn't have been able to, view some customer data.

This PR removes all console.log and console.error. Most of the removals were required to fix point 2 above though there were some that were pure simple debug output that could be left in, but were removed based on point 1.

This mirrors the contents of openwhisk-package-cloudant PR#220 https://github.com/apache/openwhisk-package-cloudant/pull/220